### PR TITLE
revolut: Handle empty balance fields

### DIFF
--- a/src/ofxstatement/plugins/revolut.py
+++ b/src/ofxstatement/plugins/revolut.py
@@ -58,7 +58,8 @@ class RevolutCSVStatementParser(CsvStatementParser):
         stmt_line = super().parse_record(line)
 
         # Generate a unique ID
-        balance = self.parse_float(line[c["Balance"]])
+        balance_content = line[c["Balance"]]
+        balance = self.parse_float(balance_content) if balance_content else 0
         stmt_line.id = md5(f"{stmt_line.date}-{stmt_line.payee}-{stmt_line.amount}-{balance}".encode())\
             .hexdigest()
 


### PR DESCRIPTION
This can happen in both investments lines or in other special cases.

Closes: #20